### PR TITLE
node: get all wallets

### DIFF
--- a/rai/node.py
+++ b/rai/node.py
@@ -1,5 +1,5 @@
 from .rpc import make_rpc, get_connection
-
+from .wallet import Wallet
 
 class Node:
 
@@ -26,3 +26,15 @@ class Node:
     @property
     def connection(self):
         return get_connection()
+
+    @property
+    def wallets(self):
+        """
+            Returns all Wallets available on the node
+        """
+        rsp = make_rpc(
+            {
+                'action': 'wallet_list'
+            }
+        )
+        return [Wallet(id=wallet_id) for wallet_id in rsp['wallets']]


### PR DESCRIPTION
This code depends on the `wallet_list` RPC method being implemented. There is a open pull request for this on the reference rai_node project: https://github.com/clemahieu/raiblocks/pull/432